### PR TITLE
Fixes minor things

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,12 @@ ENV GAMEPORT   16261
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies 
-RUN apt-get update &&\ 
-    apt-get install -y curl lib32gcc1 default-jre 
+RUN apt-get update && apt-get install -y \
+	curl \
+	lib32gcc1 \
+	default-jre \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 
 # Run commands as the steam user

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ENV STEAMPORT2  8767
 # Game port
 ENV GAMEPORT   16261
 
+# Stop apt-get asking to get Dialog frontend
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies 
 RUN apt-get update &&\ 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Docker build for project zomboid server.
 
 v1.0: First version for non steam server [now broken]  
 v1.1: New version for Project Zomboid Steam dedicated server
+v1.2: Minor fixes (asking for frontend disabled, sed parse error removed)
 
 ## Usage
 `docker run -d -e SERVERNAME="MyServerName" -e ADMINPASSWORD="myadminpassword" -e RCON_PASSWORD="rconpassword"  -v /My/path/to/My/Config/and/data:/server-data -p 16261:16261 -p 16261:16261/udp -p 8766:8766 -p 8767:8767 -p 16262-16272:16262-16272 --name zomboid turzam/zomboid`

--- a/update.sh
+++ b/update.sh
@@ -23,7 +23,7 @@ echo -e "Update project zomboid..."
 
 # Only change password is it doesn't exist
 INIFILE="/home/steam/Zomboid/Server/${SERVERNAME}.ini"
-sed -i -e s/RCONPassword=[[:space:]/RCONPassword=${RCON_PASSWORD}/ $INIFILE
+sed -i -e 's/RCONPassword=[[:space:]/RCONPassword=${RCON_PASSWORD}/' $INIFILE
 
 
 

--- a/update.sh
+++ b/update.sh
@@ -23,7 +23,7 @@ echo -e "Update project zomboid..."
 
 # Only change password is it doesn't exist
 INIFILE="/home/steam/Zomboid/Server/${SERVERNAME}.ini"
-sed -i -e 's/RCONPassword=[[:space:]/RCONPassword=${RCON_PASSWORD}/' $INIFILE
+sed -i -e "s/RCONPassword=[[:space:]/RCONPassword=${RCON_PASSWORD}/" $INIFILE
 
 
 


### PR DESCRIPTION
Fix a quotes sed issue
Remove the permanent asking for Dialog/Frontend during the apt-get install

I'll try to use debian steam repositories to make a "more friendly" server version avoiding a lot of command line.

Avoid the project zomboid update at each launch trough entrypoint [update.sh]? And only launch the server. That cost a lot and docker should launch container fast and quickly
